### PR TITLE
Added note about heroku killing idle apps

### DIFF
--- a/_docs/deployment/heroku.md
+++ b/_docs/deployment/heroku.md
@@ -10,6 +10,20 @@ order: 4.3
 
 This document will explain how to install Shout on Heroku. If you want to learn about Heroku you should read their [documentation](https://devcenter.heroku.com/articles/getting-started-with-nodejs#introduction).
 
+<div class="alert alert-warning" role="alert">
+  <p>
+    Please be aware that Heroku automatically kills unpaid apps after 1 hour of inactivity, and then spins them back up the next time a request comes in.
+    This does not apply to paid accounts.
+    If you scale up to two servers and pay for the second one, you get two always-on servers.
+    <a href="https://devcenter.heroku.com/articles/dynos\#dyno-sleeping">Read more</a>
+  </p>
+
+  <p>
+    When heroku kills shout, you need to connect to servers and channels again from scratch.
+    In practice, you get no always-on functionality with an unpaid heroku account.
+  </p>
+</div>
+
 Okay, let's get down to business:
 
 ### Step 1:

--- a/css/style.css
+++ b/css/style.css
@@ -331,3 +331,18 @@ pre code {
 		padding-top: 0;
 	}
 }
+
+.alert {
+	padding: 15px;
+	margin-bottom: 20px;
+	border: 1px solid transparent;
+	border-radius: 4px;
+}
+.alert-warning {
+	color: #8a6d3b;
+	background-color: #fcf8e3;
+	border-color: #faebcc;
+}
+.alert p:last-child {
+	margin-bottom: 0;
+}


### PR DESCRIPTION
I thought there was a bug with shout until I dug around the heroku logs and found out that heroku kills idle apps after 1 hour of no http requests. Added a warning on the heroku deployment page in the documentation.

![screenshot](https://cloud.githubusercontent.com/assets/1098408/4692764/1fa607a0-5778-11e4-9044-d5493304b85e.png)
