### PR TITLE
Fix alias list for /raw

### DIFF
--- a/_docs/client/commands.md
+++ b/_docs/client/commands.md
@@ -155,7 +155,7 @@ Example: `/raw`
 
 Aliases:
 
-- [/raw](#raw)
+- [/quote](#quote)
 - [/send](#send)
 
 ## /say


### PR DESCRIPTION
/raw was listed as an alias of itself.
