### PR TITLE
Fix GitHub Pages refusing to build

### DIFF
--- a/_docs/deployment/passenger.md
+++ b/_docs/deployment/passenger.md
@@ -57,7 +57,7 @@ server {
 
 Or Apache:
 
-```apache
+```conf
 <VirtualHost *:80>
     ServerName irc.me.com
     DocumentRoot <directory you cloned Shout to>


### PR DESCRIPTION
Replace `apache` syntax with `conf` syntax because of a bug with Jekyll 3 on GitHub Pages.
